### PR TITLE
Fix some issue with throttling from launch darkly

### DIFF
--- a/launchdarkly/resource_environment.go
+++ b/launchdarkly/resource_environment.go
@@ -140,7 +140,7 @@ func resourceEnvironmentUpdate(d *schema.ResourceData, m interface{}) error {
 		"value": color,
 	}}
 
-	_, err := client.Patch(getEnvironmentUrl(project, d.Id()), payload, []int{200})
+	_, err := client.Patch(getEnvironmentUrl(project, d.Id()), payload, []int{200}, 0)
 	if err != nil {
 		return err
 	}

--- a/launchdarkly/resource_project.go
+++ b/launchdarkly/resource_project.go
@@ -110,7 +110,7 @@ func resourceProjectUpdate(d *schema.ResourceData, m interface{}) error {
 		"value": name,
 	}}
 
-	_, err := client.Patch(getProjectUrl(d.Id()), payload, []int{200})
+	_, err := client.Patch(getProjectUrl(d.Id()), payload, []int{200}, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Merge patch call to prevent throttling from LaunchDarkly, Add a retry mechanic on the client when doing HTTP calls and use it for patch catch when getting 429.

Please note that the retry is very basic for now and could/should be rework. I think that for now, it is a good enough fix for the issue we get with this provider during our terraform deployment.